### PR TITLE
Us 4 update an item

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -8,4 +8,20 @@ class Api::V1::ItemsController < ApplicationController
     render json: ItemSerializer.new(item)
   end
 
+  def update
+    item = Item.find(params[:id])
+    if item
+      item.update(item_params)
+      render json: ItemSerializer.new(item)
+    else
+      render json: { message: "Item update failed" }
+    end
+  end
+
+  private 
+
+  def item_params
+    params.permit(:id, :name, :description, :unit_price, :merchant_id)
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
       resources :items, only: [:index, :show]
     end
   end
+
+  patch "/api/v1/items/:id", to: "api/v1/items#update"
 end

--- a/spec/requests/api/v1/items_spec.rb
+++ b/spec/requests/api/v1/items_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "Api::V1::Items", type: :request do
 
   describe "GET /api/v1/items/:id" do
     let!(:item) { create(:item) }
-
     it "returns specified item attributes" do
       get api_v1_item_path(item)
 
@@ -34,6 +33,44 @@ RSpec.describe "Api::V1::Items", type: :request do
       expect(json_response["data"]["attributes"]["description"]).to eq(item.description)
       expect(json_response["data"]["attributes"]["unit_price"]).to eq(item.unit_price)
       expect(json_response["data"]["attributes"]["merchant_id"]).to eq(item.merchant_id)
+    end
+  end
+
+  describe "PATCH /api/v1/items/:id" do 
+    it "updates a specified item's attributes" do
+      merchant = create(:merchant, id: 7)
+      json_input = {
+        "name": "value1",
+        "description": "value2",
+        "unit_price": 100.99,
+        "merchant_id": 7
+      }
+      item = Item.create!(json_input)
+      item_update = {id: item.id, name: "Turing School", description: "Best boot camp ever", unit_price: 22000.00}
+      
+      get api_v1_item_path(item)
+      
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+
+      expect(json_response["data"]["id"]).to eq(item.id.to_s)
+      expect(json_response["data"]["type"]).to eq("item")
+      expect(json_response["data"]["attributes"]["name"]).to eq("value1")
+      expect(json_response["data"]["attributes"]["description"]).to eq("value2")
+      expect(json_response["data"]["attributes"]["unit_price"]).to eq(100.99)
+      expect(json_response["data"]["attributes"]["merchant_id"]).to eq(7)
+
+      patch api_v1_item_path(item_update)
+
+      expect(response).to have_http_status(:success)
+      json_response = JSON.parse(response.body)
+
+      expect(json_response["data"]["id"]).to eq(item.id.to_s)
+      expect(json_response["data"]["type"]).to eq("item")
+      expect(json_response["data"]["attributes"]["name"]).to eq("Turing School")
+      expect(json_response["data"]["attributes"]["description"]).to eq("Best boot camp ever")
+      expect(json_response["data"]["attributes"]["unit_price"]).to eq(22000.00)
+      expect(json_response["data"]["attributes"]["merchant_id"]).to eq(7)
     end
   end
 end


### PR DESCRIPTION
Create update functionality for items.  RSpec requests passing.

Postman is a different story.  First, there is no PATCH test in Postman.  Only a PUT.  Second, when I changed the test to a PATCH, 4/5 tests pass, with the same one failing with this error message:

_happy path, works with only partial data, too | AssertionError: expected 404 to be one of [ 200, 201, 202 ]_

Strangely enough, when I make the test a PUT http verb, I still only get 4/5 tests passing, but it's a different test that fails each time, with this error message:

_edge case, bad merchant id returns 400 or 404 | AssertionError: expected 200 to be one of [ 400, 404 ]_

If we want to wait to merge until this issue is figured out, that works.  I just needed to stop the unproductive struggle.